### PR TITLE
Fix couple of bugs affecting GFSK operations

### DIFF
--- a/src/commands/dio.rs
+++ b/src/commands/dio.rs
@@ -139,7 +139,7 @@ pub struct GetIrqStatus;
 
 impl Command for GetIrqStatus {
     type IdType = u8;
-    type CommandParameters = NoParameters;
+    type CommandParameters = NopParameters<1>;
     type ResponseParameters = IrqMask;
 
     fn id() -> Self::IdType {
@@ -147,7 +147,7 @@ impl Command for GetIrqStatus {
     }
 
     fn invoking_parameters(self) -> Self::CommandParameters {
-        NoParameters::default()
+        Self::CommandParameters::default()
     }
 }
 
@@ -304,5 +304,30 @@ impl Command for SetDio3AsTcxoCtrl {
 
     fn invoking_parameters(self) -> Self::CommandParameters {
         self.config
+    }
+}
+
+/// NopParameters for use with read commands that send few zeros
+/// before the data are ready. One example of such command is
+/// GetIrqStatus.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct NopParameters<const N: usize>;
+
+impl<const N: usize> ToByteArray for NopParameters<N> {
+    type Error = Infallible;
+
+    type Array = [u8; N];
+
+    fn to_bytes(self) -> Result<Self::Array, Self::Error> {
+        Ok([0; N])
+    }
+}
+impl<const N: usize> FromByteArray for NopParameters<N> {
+    type Error = Infallible;
+
+    type Array = [u8; N];
+
+    fn from_bytes(_bytes: Self::Array) -> Result<Self, Self::Error> {
+        Ok(Self)
     }
 }

--- a/src/commands/rf.rs
+++ b/src/commands/rf.rs
@@ -35,7 +35,10 @@ impl ToByteArray for RfFrequencyConfig {
     type Array = [u8; 4];
 
     fn to_bytes(self) -> Result<Self::Array, Self::Error> {
-        Ok(self.frequency.to_be_bytes())
+        // Frequency register = (Frequency * 2^25) / FXTAL
+        let f = ((self.frequency as u64 * (1_u64 << 25)) / 32_000_000) as u32;
+
+        Ok(f.to_be_bytes())
     }
 }
 
@@ -505,8 +508,8 @@ impl ToByteArray for ModulationParams {
                 bytes[0..3].copy_from_slice(&br_val.to_be_bytes()[1..]);
                 bytes[3] = params.pulse_shape as u8;
                 bytes[4] = params.bandwidth as u8;
-                // Frequency deviation = (deviation * 2^25) / FXTAL
-                let fdev = (params.freq_deviation * 33_554_432) / 32_000_000;
+                // Frequency deviation register = (Frequency deviation * 2^25) / FXTAL
+                let fdev = ((params.freq_deviation as u64 * (1_u64 << 25)) / 32_000_000) as u32;
                 bytes[5..8].copy_from_slice(&fdev.to_be_bytes()[1..]);
             }
             ModulationParams::LoRa(params) => {

--- a/src/device.rs
+++ b/src/device.rs
@@ -74,7 +74,7 @@ where
         R: ReadableRegister<IdType = u16>,
     {
         let header = &mut [0x1D, 0x00, 0x00, 0x00];
-        header[1..].copy_from_slice(&R::id().to_be_bytes());
+        header[1..=2].copy_from_slice(&R::id().to_be_bytes());
 
         let mut raw_value = R::Array::new();
 
@@ -193,14 +193,14 @@ where
     SPI: embedded_hal_async::spi::SpiDevice,
 {
     /// Asynchronously reads a register value from the device.
-    /// 
+    ///
     /// This is the async version of [`read_register`](Device::read_register).
     pub async fn read_register_async<R>(&mut self) -> Result<R, RegifaceError>
     where
         R: ReadableRegister<IdType = u16>,
     {
         let header = &mut [0x1D, 0x00, 0x00, 0x00];
-        header[1..].copy_from_slice(&R::id().to_be_bytes());
+        header[1..=2].copy_from_slice(&R::id().to_be_bytes());
 
         let mut raw_value = R::Array::new();
 


### PR DESCRIPTION
Hi, this fixes three issues I found when trying to use the lib.

- panic when calling read_register (souce and destination size must match in copy_from_slice)
- wrong data retrieved from GetIrqStatus, because one NOP byte was missing
- the GFSK frequency was not converted to PLL steps