### PR TITLE
fix: RX and TX timeout should be 24 bits, not 32 bits

### DIFF
--- a/src/commands/operational.rs
+++ b/src/commands/operational.rs
@@ -161,10 +161,12 @@ pub struct Timeout(pub u32);
 
 impl ToByteArray for Timeout {
     type Error = Infallible;
-    type Array = [u8; 4];
+    type Array = [u8; 3];
 
     fn to_bytes(self) -> Result<Self::Array, Self::Error> {
-        Ok(self.0.to_be_bytes())
+        let mut bytes = [0u8; 3];
+        bytes.copy_from_slice(&self.0.to_be_bytes()[1..4]);
+        Ok(bytes)
     }
 }
 


### PR DESCRIPTION
According to the datasheet I have, the timeout for SetTX and SetRX should be 24 bits and not the 32 bits it is now.