### PR TITLE
Fix panics when unwrapping Err(InvalidCommandStatus(InvalidValue(1)))

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -177,12 +177,12 @@ pub struct GetRssiInstResponse {
 }
 
 impl FromByteArray for GetRssiInstResponse {
-    type Error = Infallible;
+    type Error = StatusError;
     type Array = [u8; 2]; // 1 status byte + 1 RSSI byte
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
+            status: Status::from_bytes([bytes[0]])?,
             rssi: bytes[1],
         })
     }
@@ -253,13 +253,14 @@ pub struct GetRxBufferStatusResponse {
 }
 
 impl FromByteArray for GetRxBufferStatusResponse {
-    type Error = Infallible;
+    type Error = StatusError;
     type Array = [u8; 3]; // 1 status byte + 2 buffer bytes
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
-            buffer_status: RxBufferStatus::from_bytes([bytes[1], bytes[2]]).unwrap(),
+            status: Status::from_bytes([bytes[0]])?,
+            buffer_status: RxBufferStatus::from_bytes([bytes[1], bytes[2]])
+                .expect("this is infallible"),
         })
     }
 }
@@ -338,13 +339,14 @@ pub struct GetPacketStatusResponse {
 }
 
 impl FromByteArray for GetPacketStatusResponse {
-    type Error = Infallible;
+    type Error = StatusError;
     type Array = [u8; 4]; // 1 status byte + 3 packet status bytes
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
-            packet_status: PacketStatus::from_bytes([bytes[1], bytes[2], bytes[3]]).unwrap(),
+            status: Status::from_bytes([bytes[0]])?,
+            packet_status: PacketStatus::from_bytes([bytes[1], bytes[2], bytes[3]])
+                .expect("infallible"),
         })
     }
 }
@@ -430,13 +432,13 @@ pub struct GetDeviceErrorsResponse {
 }
 
 impl FromByteArray for GetDeviceErrorsResponse {
-    type Error = Infallible;
+    type Error = StatusError;
     type Array = [u8; 3]; // 1 status byte + 2 error bytes
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
-            errors: DeviceErrors::from_bytes([bytes[1], bytes[2]]).unwrap(),
+            status: Status::from_bytes([bytes[0]])?,
+            errors: DeviceErrors::from_bytes([bytes[1], bytes[2]]).expect("infallible"),
         })
     }
 }
@@ -540,9 +542,9 @@ impl FromByteArray for Stats {
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            packets_received: u16::from_be_bytes(bytes[0..2].try_into().unwrap()),
-            packets_crc_error: u16::from_be_bytes(bytes[2..4].try_into().unwrap()),
-            packets_header_error: u16::from_be_bytes(bytes[4..6].try_into().unwrap()),
+            packets_received: u16::from_be_bytes(bytes[0..2].try_into().expect("infallible")),
+            packets_crc_error: u16::from_be_bytes(bytes[2..4].try_into().expect("infallible")),
+            packets_header_error: u16::from_be_bytes(bytes[4..6].try_into().expect("infallible")),
         })
     }
 }
@@ -559,14 +561,14 @@ pub struct GetStatsResponse {
 }
 
 impl FromByteArray for GetStatsResponse {
-    type Error = Infallible;
+    type Error = StatusError;
     type Array = [u8; 7]; // 1 status byte + 6 stats bytes
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
+            status: Status::from_bytes([bytes[0]])?,
             stats: Stats::from_bytes([bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6]])
-                .unwrap(),
+                .expect("infallible"),
         })
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -24,8 +24,8 @@
 //! device.write_buffer(0, &[0x01, 0x02, 0x03])?;
 //! ```
 
-use core::convert::Infallible;
-
+use core::{convert::Infallible, fmt::Debug};
+use log::{info, warn};
 use regiface::{
     errors::Error as RegifaceError, ByteArray, Command, FromByteArray, ReadableRegister,
     ToByteArray, WritableRegister,
@@ -171,8 +171,13 @@ where
     where
         C: Command<IdType = u8>,
         C::CommandParameters: ToByteArray<Error = Infallible>,
+        <C as Command>::ResponseParameters: Debug,
     {
-        let request = command.invoking_parameters().to_bytes().unwrap();
+        let request = command
+            .invoking_parameters()
+            .to_bytes()
+            .map_err(|_| RegifaceError::SerializationError)?;
+
         let mut raw_response = <C::ResponseParameters as FromByteArray>::Array::new();
 
         self.spi
@@ -183,8 +188,14 @@ where
             ])
             .map_err(|_| RegifaceError::BusError)?;
 
-        C::ResponseParameters::from_bytes(raw_response)
-            .map_err(|_| RegifaceError::DeserializationError)
+        let response = C::ResponseParameters::from_bytes(raw_response);
+
+        let response = match response {
+            Ok(r) => Ok(r),
+            Err(e) => Err(e),
+        };
+
+        response.map_err(|_| RegifaceError::DeserializationError)
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use core::{convert::Infallible, fmt::Debug};
-use log::{info, warn};
 use regiface::{
     errors::Error as RegifaceError, ByteArray, Command, FromByteArray, ReadableRegister,
     ToByteArray, WritableRegister,


### PR DESCRIPTION
Fix panics on invalid command status values. I ran into this intermittently when running this code on an ESP32. It generally took a pretty long time for the problem to surface, but when it did, this was the error I saw:

```
called `Result::unwrap()` on an `Err` value: InvalidCommandStatus(InvalidValue(1)) Some(Location { file: "src/commands/status.rs", line: 261, column: 52 })
```