### PR TITLE
FIX GetIrqStatusResponse

### DIFF
--- a/src/commands/dio.rs
+++ b/src/commands/dio.rs
@@ -142,8 +142,8 @@ impl FromByteArray for GetIrqStatusResponse {
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {
-            status: Status::from_bytes([bytes[0]]).unwrap(),
-            irq_mask: IrqMask::from_bytes([bytes[1], bytes[2]]).unwrap(),
+            status: Status::from_bytes([bytes[1]]).unwrap(),
+            irq_mask: IrqMask::from_bytes([bytes[2], bytes[3]]).unwrap(),
         })
     }
 }

--- a/src/commands/dio.rs
+++ b/src/commands/dio.rs
@@ -138,7 +138,7 @@ pub struct GetIrqStatusResponse {
 
 impl FromByteArray for GetIrqStatusResponse {
     type Error = Infallible;
-    type Array = [u8; 3]; // 1 status byte + 2 IRQ bytes
+    type Array = [u8; 4]; // 1 RFU byte + 1 status byte + 2 IRQ-status bytes
 
     fn from_bytes(bytes: Self::Array) -> Result<Self, Self::Error> {
         Ok(Self {


### PR DESCRIPTION
Regarding section 13.3.3 GetIrqStatus, the data returned to the host contains 4 bytes: #1: RFU, #2: Status, #3 and #4: IrqStatus:
<img width="930" height="334" alt="image" src="https://github.com/user-attachments/assets/d4f46e64-083d-4880-b780-af7cbeda99ba" />

So byte#1 (or byte[0], if you count from 0) is reserved for future use.