### PR TITLE
FIX-GetPacketType: add a NOP

### DIFF
--- a/src/commands/rf.rs
+++ b/src/commands/rf.rs
@@ -142,7 +142,7 @@ pub struct GetPacketType;
 
 impl Command for GetPacketType {
     type IdType = u8;
-    type CommandParameters = NoParameters;
+    type CommandParameters = regiface::Zeros::<1>;
     type ResponseParameters = PacketType;
 
     fn id() -> Self::IdType {
@@ -150,7 +150,7 @@ impl Command for GetPacketType {
     }
 
     fn invoking_parameters(self) -> Self::CommandParameters {
-        NoParameters::default()
+        CommandParameters::default()
     }
 }
 

--- a/src/commands/rf.rs
+++ b/src/commands/rf.rs
@@ -150,7 +150,7 @@ impl Command for GetPacketType {
     }
 
     fn invoking_parameters(self) -> Self::CommandParameters {
-        CommandParameters::default()
+        Self::CommandParameters::default()
     }
 }
 


### PR DESCRIPTION
`GetPacketType` requires a `NOP` (`0x00`) parameter, before reading `packetType`. If the `NOP` is skipped, `Status` is read, instead of `packetType`. This is described in section 13.4.3.

<img width="1156" height="320" alt="image" src="https://github.com/user-attachments/assets/3ebef237-59ad-4ff3-be39-4aa2c5ce0e9f" />
